### PR TITLE
chore(fastapi): 0.104.1 -> 0.105.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.104.1
+fastapi==0.105.0
 qrcode==7.4.2
 Pillow==10.1.0
 uvicorn[standard]==0.24.0


### PR DESCRIPTION
looks like none of the changes impact us - https://fastapi.tiangolo.com/release-notes/